### PR TITLE
Do an apt-get upgrade after the apt-get update

### DIFF
--- a/src/main/resources/com/enjapan/sbt/packer/packer.json.template
+++ b/src/main/resources/com/enjapan/sbt/packer/packer.json.template
@@ -23,6 +23,7 @@
       "inline": [
         "sudo add-apt-repository -y ppa:webupd8team/java",
         "sudo apt-get update",
+        "sudo apt-get upgrade",
         "echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections",
         "sudo apt-get install -y oracle-java8-installer",
         "sudo dpkg -i ${{destination}}"

--- a/src/main/resources/com/enjapan/sbt/packer/packer.json.template
+++ b/src/main/resources/com/enjapan/sbt/packer/packer.json.template
@@ -23,7 +23,7 @@
       "inline": [
         "sudo add-apt-repository -y ppa:webupd8team/java",
         "sudo apt-get update",
-        "sudo apt-get upgrade",
+        "sudo apt-get -y upgrade",
         "echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections",
         "sudo apt-get install -y oracle-java8-installer",
         "sudo dpkg -i ${{destination}}"

--- a/src/main/scala/Packer.scala
+++ b/src/main/scala/Packer.scala
@@ -79,6 +79,7 @@ object Packer {
   val installJava:ShellProvisioner = ShellProvisioner(Seq(
     "sudo add-apt-repository -y ppa:webupd8team/java",
     "sudo apt-get update",
+    "sudo apt-get -y upgrade",
     "echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections",
     "sudo apt-get install -y oracle-java8-installer"
   ))


### PR DESCRIPTION
Without an apt-get upgrade after apt-get update Java doesn't install itself anymore.

I get this error:

``` shell
    amazon-ebs: Some packages could not be installed. This may mean that you have
    amazon-ebs:
    amazon-ebs: requested an impossible situation or if you are using the unstable
    amazon-ebs: distribution that some required packages have not yet been created
    amazon-ebs: or been moved out of Incoming.
    amazon-ebs: The following information may help to resolve the situation:
    amazon-ebs:
    amazon-ebs: The following packages have unmet dependencies:
    amazon-ebs: oracle-java8-installer : Depends: java-common (>= 0.24) but it is not installable
    amazon-ebs: Recommends: gsfonts-x11 but it is not installable
    amazon-ebs: E: Unable to correct problems, you have held broken packages.
```
